### PR TITLE
feat(Tags): adding tagModel, tagRouter, tagController, and blogpost's middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ note on symbols:<br/>
 ## Sign Up
 
 ```HTTP
-POST /api/v1/users/signup
+POST /api/2/users/signup
 ```
 Create a new account in myMiniBlog app. The account is identified by email so the field should be unique per account. Token is immediately saved when signing up is successful. You cannot assign user's role through this API endpoint.
 
@@ -83,7 +83,7 @@ Create a new account in myMiniBlog app. The account is identified by email so th
 ## Log In
 
 ```HTTP
-POST /api/v1/users/login
+POST /api/v2/users/login
 ```
 Get token for registered user. The token will be saved in cookies and have expired date set in 24 hours after logging in.
 
@@ -115,7 +115,7 @@ Get token for registered user. The token will be saved in cookies and have expir
 ## Forgot Password
 
 ```HTTP
-POST /api/v1/users/login
+POST /api/v2/users/login
 ```
 Get an email containing token to reset password sent to the address provided. The token will immediately be sent and valid for 10 minutes after it was sent.
 
@@ -136,7 +136,7 @@ Get an email containing token to reset password sent to the address provided. Th
 
 ## Reset Password
 ```HTTP
-PATCH /api/v1/users/resetPassword/:token
+PATCH /api/v2/users/resetPassword/:token
 ```
 Change user's password by the token sent in email after accessing Forgot Password API endpoint.
 
@@ -167,7 +167,7 @@ Change user's password by the token sent in email after accessing Forgot Passwor
 ```
 ## Update Current User Password
 ```HTTP
-PATCH /api/v1/users/resetPassword/:token
+PATCH /api/v2/users/resetPassword/:token
 ```
 🔒 Change user's password from myMiniBlog's account menu. The user needs to type in old password to change it. 
 
@@ -202,7 +202,7 @@ PATCH /api/v1/users/resetPassword/:token
 ## Get All Users
 
 ```HTTP
-GET /api/v1/users/
+GET /api/v2/users/
 ```
 🎫 Get all registered users that has not been deactivated. This API endpoint can only be accessed by admins. 
 
@@ -234,7 +234,7 @@ GET /api/v1/users/
 ## Get Current User
 
 ```HTTP
-GET /api/v1/users/me
+GET /api/v2/users/me
 ```
 🔒 Get informations of the current logged in user. JWT token is needed in order to search for user.
 
@@ -257,7 +257,7 @@ GET /api/v1/users/me
 
 ## Get User
 ```HTTP
-GET /api/v1/users/:id
+GET /api/v2/users/:id
 ```
 Get user's data by providing user's ID param in API endpoint.
 
@@ -280,11 +280,11 @@ Get user's data by providing user's ID param in API endpoint.
 
 ## Get Users by nameRegex
 ```HTTP
-GET /api/v1/users/search/:nameRegex
+GET /api/v2/users/search/:nameRegex
 ```
 Get users' data which user's name is matching the regex keyword provided. The name search is case insensitive and the result will provide id and name fields.
 
-**Response for /api/v1/users/search/b**
+**Response for /api/v2/users/search/b**
 ```HTTP
 {
     "status": "success",
@@ -304,7 +304,7 @@ Get users' data which user's name is matching the regex keyword provided. The na
 
 ## Update Current User
 ```HTTP
-PATCH /api/v1/users/updateMe
+PATCH /api/v2/users/updateMe
 ```
 🔒 Change the current logged in user's name, email, and/or photo. You cannot change user's password or role through this API endpoint. 
 
@@ -333,7 +333,7 @@ PATCH /api/v1/users/updateMe
 ```
 ## Update User
 ```HTTP
-PATCH /api/v1/users/:id
+PATCH /api/v2/users/:id
 ```
 🎫 Update user by provided ID, cannot upload image and change password through this API endpoint. Access for admins only.
 
@@ -367,13 +367,13 @@ PATCH /api/v1/users/:id
 
 ## Delete Current User
 ```HTTP
-DELETE /api/v1/users/deleteMe
+DELETE /api/v2/users/deleteMe
 ```
 🔒 Set active: false for the current logged in user and hide data from showing in API responses.
 
 ## Delete User
 ```HTTP
-DELETE /api/v1/users/:id
+DELETE /api/v2/users/:id
 ```
 🎫 Remove user data permanently from mongoDB. Only admins can do this action. 
 
@@ -384,7 +384,7 @@ DELETE /api/v1/users/:id
 ## Create New Blogpost 
 
 ```HTTP
-POST /api/v1/blogposts
+POST /api/v2/blogposts
 ```
 🔒 Create a new blogpost by providing title and content at minimum. You can also add tags to your post before updating blogpost for image inclusion.
 
@@ -426,7 +426,7 @@ POST /api/v1/blogposts
 ## Get All Blogposts
 
 ```HTTP
-GET /api/v1/blogposts
+GET /api/v2/blogposts
 ```
 
 Get all active blogposts that had been created before. The response is sorted by blogpost's createdAt from new to old.
@@ -478,7 +478,7 @@ Get all active blogposts that had been created before. The response is sorted by
 ```
 ## Get All Tags
 ```HTTP
-GET /api/v1/blogposts/alltags
+GET /api/v2/blogposts/alltags
 ```
 Get all tags that had been used in myMiniBlog before. 
 
@@ -499,7 +499,7 @@ Get all tags that had been used in myMiniBlog before.
 ```
 ## Get Blogposts by Tags
 ```HTTP
-GET /api/v1/blogposts/tags/:tag
+GET /api/v2/blogposts/tags/:tag
 ```
 Get all blogposts by filtering its owned tags. You can input multiple tags by inserting the parameters divided by comma. Query filter works the same way as [Get All Blogposts](#get-all-blogposts) API endpoint. The response returned is also in the same format as Get All Blogposts' response.
 
@@ -535,7 +535,7 @@ Get all blogposts by filtering its owned tags. You can input multiple tags by in
 ## Get Blogpost
 
 ```HTTP
-GET /api/v1/blogposts/:id
+GET /api/v2/blogposts/:id
 ```
 Call a single blogpost by its ID and get the requested document with all embedded comment section.  
 
@@ -600,7 +600,7 @@ Call a single blogpost by its ID and get the requested document with all embedde
 ## Update Blogpost
 
 ```HTTP
-PATCH /api/v1/blogposts/:id
+PATCH /api/v2/blogposts/:id
 ```
 
 🔒 Edit user's blogpost including adding blogpostImg and bannerImg. blogpostImg will be used to post's representative picture in main page and thumbnail with size of ,  Only user who wrote the post and admins can perform this action.
@@ -646,7 +646,7 @@ PATCH /api/v1/blogposts/:id
 ```
 ## Delete Blogpost
 ```HTTP
-DELETE /api/v1/blogposts/:id
+DELETE /api/v2/blogposts/:id
 ```
 🔒 Delete a blogpost and its comments by providing the blogpost's ID.
 
@@ -657,7 +657,7 @@ DELETE /api/v1/blogposts/:id
 
 ## Create New Comment
 ```HTTP
-POST /api/v1/comments/
+POST /api/v2/comments/
 ```
 🔒 Create new comment by posting string of comment and blogpost's ID. User's ID is derived from the current logged in user's JWT token.
 
@@ -688,7 +688,7 @@ POST /api/v1/comments/
 ```
 ## Get All Comments
 ```HTTP
-GET /api/v1/comments/
+GET /api/v2/comments/
 ```
 Get all posted comments from all the blogposts and users, sorted from oldest to newest by default. 
 
@@ -734,7 +734,7 @@ Get all posted comments from all the blogposts and users, sorted from oldest to 
 
 ## Get Comment
 ```HTTP
-GET /api/v1/comments/:id
+GET /api/v2/comments/:id
 ```
 Call a single comment by its ID and get the requested document with blogpost title it posted to and the user who had written it.  
 
@@ -766,7 +766,7 @@ Call a single comment by its ID and get the requested document with blogpost tit
 
 ## Update Comment
 ```HTTP
-PATCH /api/v1/comments/:id
+PATCH /api/v2/comments/:id
 ```
 🔒 Save new data for comment with ID provided in endpoint. Only user who wrote the comment and admins can update. The `user` field will persist unless an admin decided to input new ID. `updatedAt` field will be marked by `Date.now()`.
 
@@ -798,7 +798,7 @@ PATCH /api/v1/comments/:id
 
 ## Delete Comment
 ```HTTP
-DELETE /api/v1/comments/:id
+DELETE /api/v2/comments/:id
 ```
 🔒 Delete a comment by its ID. Deleting a comment will automatically update commentsNum for the associated blogpost. Note: this endpoint can be accessed by every user logged in and not secured for only the user making comment.
 
@@ -810,7 +810,7 @@ DELETE /api/v1/comments/:id
 
 ## Create New Comment by BlogpostId
 ```HTTP
-POST /api/v1/blogposts/:blogpostId/comments
+POST /api/v2/blogposts/:blogpostId/comments
 ```
 🔒 Create new comment by inputing blogpost's ID in API endpoint. User's ID is derived from the current logged in user's JWT token.
 
@@ -840,7 +840,7 @@ POST /api/v1/blogposts/:blogpostId/comments
 ```
 ## Get All Comments by BlogpostId
 ```HTTP
-GET /api/v1/blogposts/:blogpostId/comments
+GET /api/v2/blogposts/:blogpostId/comments
 ```
 Get all posted comments from specified blogpost, sorted from oldest to newest by default. 
 
@@ -873,7 +873,7 @@ Get all posted comments from specified blogpost, sorted from oldest to newest by
 
 ## Get Blogposts by UserId
 ```HTTP
-GET /api/v1/users/:userId/blogposts
+GET /api/v2/users/:userId/blogposts
 ```
 Get all blogposts that had been posted by a user.
 
@@ -910,7 +910,7 @@ Get all blogposts that had been posted by a user.
 
 ## Get All Comments by UserId
 ```HTTP
-GET /api/v1/users/:userId/comments
+GET /api/v2/users/:userId/comments
 ```
 Get all comments that had been posted by a user.
 

--- a/app.js
+++ b/app.js
@@ -14,10 +14,11 @@ const globalErrorHandler = require("./controllers/errorController");
 const userRouter = require("./routes/userRoutes");
 const blogpostRouter = require("./routes/blogpostRoutes");
 const commentRouter = require("./routes/commentRoutes");
+const tagRouter = require("./routes/tagRoutes");
 
 const app = express();
 
-app.enable("trust proxy");
+// app.enable("trust proxy");
 
 app.use(cors());
 app.options("*", cors());
@@ -47,6 +48,7 @@ app.use(compression());
 app.use("/api/v1/users", userRouter);
 app.use("/api/v1/blogposts", blogpostRouter);
 app.use("/api/v1/comments", commentRouter);
+app.use("/api/v1/tags", tagRouter);
 
 app.all("*", (req, res, next) => {
   next(new AppError(`Can't find ${req.originalUrl} on this server!`, 404));

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ const tagRouter = require("./routes/tagRoutes");
 
 const app = express();
 
-// app.enable("trust proxy");
+app.enable("trust proxy");
 
 app.use(cors());
 app.options("*", cors());
@@ -45,10 +45,10 @@ app.use(hpp({ whitelist: ["user"] }));
 
 app.use(compression());
 
-app.use("/api/v1/users", userRouter);
-app.use("/api/v1/blogposts", blogpostRouter);
-app.use("/api/v1/comments", commentRouter);
-app.use("/api/v1/tags", tagRouter);
+app.use("/api/v2/users", userRouter);
+app.use("/api/v2/blogposts", blogpostRouter);
+app.use("/api/v2/comments", commentRouter);
+app.use("/api/v2/tags", tagRouter);
 
 app.all("*", (req, res, next) => {
   next(new AppError(`Can't find ${req.originalUrl} on this server!`, 404));

--- a/controllers/blogpostController.js
+++ b/controllers/blogpostController.js
@@ -79,38 +79,7 @@ exports.setCreateBlogpostUserId = (req, res, next) => {
 };
 exports.createBlogpost = factory.createOne(Blogpost);
 
-// exports.getAllTags = catchAsync(async (req, res, next) => {
-//   const tags = await Blogpost.distinct("tags");
-
-//   res.status(200).json({
-//     status: "success",
-//     data: {
-//       tags,
-//     },
-//   });
-// });
-
-// exports.setSearchBlogpostsTags = (req, res, next) => {
-//   if (req.params.tag.includes(",")) {
-//     const tagsParam = req.params.tag
-//       .replace(/, /g, ",")
-//       .split(",")
-//       .filter((tagName) => tagName.length > 0);
-
-//     req.query.tags = { $all: tagsParam };
-//   } else {
-//     req.query.tags = req.params.tag;
-//   }
-//   next();
-// };
-
-const allBlogpostsPopOptions = [
-  {
-    path: "user",
-    select: "name",
-  },
-];
-exports.getAllBlogposts = factory.getAll(Blogpost, allBlogpostsPopOptions);
+exports.getAllBlogposts = factory.getAll(Blogpost);
 
 const blogpostPopOptions = [
   {
@@ -139,7 +108,6 @@ exports.deleteBlogpostTags = catchAsync(async (req, res, next) => {
       tagsToUpdate.push(selectedTags[i]);
     }
   }
-
   // Prepare for bulkWrite (underscore symbol is important)
   const bulkWriteArr = [];
   tagsToDelete.forEach((tag) => {

--- a/controllers/blogpostController.js
+++ b/controllers/blogpostController.js
@@ -77,7 +77,20 @@ exports.setCreateBlogpostUserId = (req, res, next) => {
   req.body._id = new mongoose.mongo.ObjectId();
   next();
 };
+
 exports.createBlogpost = factory.createOne(Blogpost);
+
+exports.setTagsQueryToSliceSearch = (req, res, next) => {
+  if (req.query.tags && req.query.tags.includes(",")) {
+    const tagsArr = req.query.tags
+      .replace(/, /g, ",")
+      .split(",")
+      .filter((tagName) => tagName.length > 0);
+    req.query.tags = { $all: tagsArr };
+  }
+
+  next();
+};
 
 exports.getAllBlogposts = factory.getAll(Blogpost);
 
@@ -129,5 +142,9 @@ exports.deleteBlogpostComments = catchAsync(async (req, res, next) => {
   await Comment.deleteMany({ blogpost: req.params.id });
   next();
 });
+
+// exports.deleteBlogpostImages = catchAsync(async (req, res, next) => {
+
+// });
 
 exports.deleteBlogpost = factory.deleteOne(Blogpost);

--- a/controllers/blogpostController.js
+++ b/controllers/blogpostController.js
@@ -21,9 +21,9 @@ exports.uploadBlogpostImages = uploadToMemory(maxSize).fields([
 exports.checkTitleSlug = catchAsync(async (req, res, next) => {
   let skipImgAndTagUpdates = false;
 
-  if (!req.body.title) {
+  if (!req.params.id && !req.body.title) {
     skipImgAndTagUpdates = true;
-  } else {
+  } else if (req.body.title) {
     req.body.slug = slugify(req.body.title, { lower: true, strict: true });
     const postWithSameSlug = await Blogpost.findOne({ slug: req.body.slug });
 
@@ -99,7 +99,6 @@ exports.uploadBlogpostImgToCloud = catchAsync(async (req, res, next) => {
     thumbImgId,
   );
   req.body.blogthumbImg = getImgUrl(thumbImgUploaded);
-
   next();
 });
 

--- a/controllers/blogpostController.js
+++ b/controllers/blogpostController.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const { uploadToMemory } = require("../utils/multerImage");
 const {
   uploadImgToCloudinary,
@@ -30,7 +31,7 @@ exports.uploadBannerImgToCloud = catchAsync(async (req, res, next) => {
   const bannerImgBuffer =
     await bannerImgSource.generateImgBufferPrioritizeWidth(outputSize);
 
-  const identifier = { flag: "banner", modelId: req.params.id };
+  const identifier = { flag: "banner", modelId: req.params.id || req.body._id };
   const bannerUploaded = await uploadImgToCloudinary(
     bannerImgBuffer,
     identifier,
@@ -50,7 +51,10 @@ exports.uploadBlogpostImgToCloud = catchAsync(async (req, res, next) => {
   const postImgBuffer =
     await imgSource.generateImgBufferPrioritizeWidth(postImgSize);
 
-  const postImgId = { flag: "blogpost", modelId: req.params.id };
+  const postImgId = {
+    flag: "blogpost",
+    modelId: req.params.id || req.body._id,
+  };
   const postImgUploaded = await uploadImgToCloudinary(postImgBuffer, postImgId);
   req.body.blogpostImg = getImgUrl(postImgUploaded);
 
@@ -69,6 +73,7 @@ exports.uploadBlogpostImgToCloud = catchAsync(async (req, res, next) => {
 
 exports.setCreateBlogpostUserId = (req, res, next) => {
   if (!req.body.user) req.body.user = req.user.id;
+  req.body._id = new mongoose.mongo.ObjectId();
   next();
 };
 exports.createBlogpost = factory.createOne(Blogpost);

--- a/controllers/blogpostController.js
+++ b/controllers/blogpostController.js
@@ -73,30 +73,30 @@ exports.setCreateBlogpostUserId = (req, res, next) => {
 };
 exports.createBlogpost = factory.createOne(Blogpost);
 
-exports.getAllTags = catchAsync(async (req, res, next) => {
-  const tags = await Blogpost.distinct("tags");
+// exports.getAllTags = catchAsync(async (req, res, next) => {
+//   const tags = await Blogpost.distinct("tags");
 
-  res.status(200).json({
-    status: "success",
-    data: {
-      tags,
-    },
-  });
-});
+//   res.status(200).json({
+//     status: "success",
+//     data: {
+//       tags,
+//     },
+//   });
+// });
 
-exports.setSearchBlogpostsTags = (req, res, next) => {
-  if (req.params.tag.includes(",")) {
-    const tagsParam = req.params.tag
-      .replace(/, /g, ",")
-      .split(",")
-      .filter((tagName) => tagName.length > 0);
+// exports.setSearchBlogpostsTags = (req, res, next) => {
+//   if (req.params.tag.includes(",")) {
+//     const tagsParam = req.params.tag
+//       .replace(/, /g, ",")
+//       .split(",")
+//       .filter((tagName) => tagName.length > 0);
 
-    req.query.tags = { $all: tagsParam };
-  } else {
-    req.query.tags = req.params.tag;
-  }
-  next();
-};
+//     req.query.tags = { $all: tagsParam };
+//   } else {
+//     req.query.tags = req.params.tag;
+//   }
+//   next();
+// };
 
 const allBlogpostsPopOptions = [
   {

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -70,6 +70,11 @@ exports.updateTagsFromEdittedPost = catchAsync(async (req, res, next) => {
   const prevBlogpost = await Blogpost.findById(req.params.id);
   const prevTags = prevBlogpost.tags || [];
 
+  // Tag query "NULL" will update previously saved tags to none
+  if (req.body.tags === "NULL") {
+    req.body.tags = [];
+  }
+
   req.body.tags = parseToTagArr(req.body.tags);
   const currentTags = [...req.body.tags];
 

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -6,6 +6,8 @@ const APIFeatures = require("../utils/apiFeatures");
 
 exports.createTag = factory.createOne(Tag);
 
+/** UPDATING FROM BLOGPOST'S TAGS **/
+
 async function inputTagIntoDB(tag, blogpostId) {
   const selectedTag = await Tag.findOne({ tag });
 
@@ -99,6 +101,8 @@ exports.updateTagsFromEdittedPost = catchAsync(async (req, res, next) => {
   next();
 });
 
+/** TAG MODEL'S DIRECT CONTROLLER **/
+
 exports.setBlogpostIdSearch = (req, res, next) => {
   if (req.params.blogpostId) {
     req.query.blogposts = req.params.blogpostId;
@@ -107,46 +111,25 @@ exports.setBlogpostIdSearch = (req, res, next) => {
   next();
 };
 
-// function addOperatorToTags(tagQuery, operator) {
-//   console.log(`tagQuery ${operator}: `, tagQuery);
-//   if (tagQuery.includes(",")) {
-//     const tagsArr = tagQuery
-//       .replace(/, /g, ",")
-//       .split(",")
-//       .filter((tagName) => tagName.length > 0);
+exports.setSearchOperatorsToQuery = (req, res, next) => {
+  if (req.query.tag && req.query.tag.includes(",")) {
+    const tagsArr = req.query.tag
+      .replace(/, /g, ",")
+      .split(",")
+      .filter((tagName) => tagName.length > 0);
+    req.query.tag = { $in: tagsArr };
+  }
 
-//     let queryInsert;
+  if (req.query.blogposts && req.query.blogposts.includes(",")) {
+    const blogsArr = req.query.blogposts
+      .replace(/, /g, ",")
+      .split(",")
+      .filter((blogpostId) => blogpostId.length > 0);
+    req.query.blogposts = { $all: blogsArr };
+  }
 
-//     // { {operator}: tagsArr };
-//     // console.log("queryInsert1", queryInsert);
-//     // queryInsert = JSON.stringify(queryInsert).replace(
-//     //   operator,
-//     //   (match) => `$${match}`,
-//     // );
-//     // console.log("queryInsert2", queryInsert)
-//     // queryInsert = JSON.parse(queryInsert);
-
-//     return queryInsert;
-//   }
-//   return tagQuery;
-// }
-
-// exports.setTagQueryWithOperators = (req, res, next) => {
-//   // normal behavior is returning union search if multiple tags provided
-//   req.query.tag = addOperatorToTags(req.query.tag, "in");
-
-//   if (!req.query["tag[in]"] || !req.query["tag[all]"]) {
-//     return next();
-//   }
-
-//   // adding $in operator to get result for union search
-//   req.query.tag = addOperatorToTags(req.query["tag[in]"], "in");
-
-//   // adding $all operator to get result for slice search, override union search
-//   req.query.tag = addOperatorToTags(req.query["tag[all]"], "all");
-
-//   next();
-// };
+  next();
+};
 
 exports.getAllTags = catchAsync(async (req, res, next) => {
   const tagQuery = Tag.find();

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -1,7 +1,40 @@
 const Tag = require("../models/tagModel");
+const catchAsync = require("../utils/catchAsync");
 const factory = require("./handlerFactory");
 
 exports.createTag = factory.createOne(Tag);
+
+async function inputTagIntoDB(tag, blogpostId) {
+  let currentTag = await Tag.findOne({ tag });
+
+  if (currentTag) {
+    currentTag.blogposts.push(blogpostId);
+    await currentTag.save();
+  } else {
+    currentTag = await Tag.create({ tag, blogposts: [blogpostId] });
+  }
+
+  return {
+    status: "success",
+    data: currentTag,
+  };
+}
+
+exports.updateTagFromNewPost = catchAsync(async (req, res, next) => {
+  if (!req.body.tags) next();
+
+  let tagArr = [];
+  if (typeof req.body.tags === "string" && req.body.tags.includes("[")) {
+    req.body.tags = JSON.parse(req.body.tags);
+  } else if (typeof req.body.tags === "string") {
+    req.body.tags = [req.body.tags];
+  }
+  tagArr = [...req.body.tags];
+
+  const tagPromises = tagArr.map((tag) => inputTagIntoDB(tag, req.body._id));
+  await Promise.all(tagPromises);
+  next();
+});
 
 exports.setBlogpostIdSearch = (req, res, next) => {
   if (req.params.blogpostId) {

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -1,38 +1,100 @@
 const Tag = require("../models/tagModel");
+const Blogpost = require("../models/blogpostModel");
 const catchAsync = require("../utils/catchAsync");
 const factory = require("./handlerFactory");
 
 exports.createTag = factory.createOne(Tag);
 
 async function inputTagIntoDB(tag, blogpostId) {
-  let currentTag = await Tag.findOne({ tag });
+  const selectedTag = await Tag.findOne({ tag });
 
-  if (currentTag) {
-    currentTag.blogposts.push(blogpostId);
-    await currentTag.save();
+  if (selectedTag) {
+    selectedTag.blogposts.push(blogpostId);
+    await selectedTag.save();
   } else {
-    currentTag = await Tag.create({ tag, blogposts: [blogpostId] });
+    await Tag.create({ tag, blogposts: [blogpostId] });
   }
 
-  return {
-    status: "success",
-    data: currentTag,
-  };
+  return 0;
 }
 
-exports.updateTagFromNewPost = catchAsync(async (req, res, next) => {
+async function deleteTagFromDB(tag, blogpostId) {
+  const selectedTag = await Tag.findOne({ tag });
+
+  if (!selectedTag) {
+    return 1;
+  }
+
+  if (!selectedTag.blogposts.includes(blogpostId)) {
+    return 1;
+  }
+
+  if (selectedTag.blogposts.length < 2) {
+    await selectedTag.deleteOne();
+    return 0;
+  }
+
+  selectedTag.blogposts.splice(selectedTag.blogposts.indexOf(blogpostId), 1);
+  return 0;
+}
+
+function parseToTagArr(tagsInput) {
+  if (typeof tagsInput === "string" && tagsInput.includes("[")) {
+    return JSON.parse(tagsInput);
+  }
+  if (typeof tagsInput === "string") {
+    return [tagsInput];
+  }
+  return tagsInput;
+}
+
+exports.updateTagsFromNewPost = catchAsync(async (req, res, next) => {
   if (!req.body.tags) next();
 
-  let tagArr = [];
-  if (typeof req.body.tags === "string" && req.body.tags.includes("[")) {
-    req.body.tags = JSON.parse(req.body.tags);
-  } else if (typeof req.body.tags === "string") {
-    req.body.tags = [req.body.tags];
-  }
-  tagArr = [...req.body.tags];
+  req.body.tags = parseToTagArr(req.body.tags);
+  const tagArr = [...req.body.tags];
 
   const tagPromises = tagArr.map((tag) => inputTagIntoDB(tag, req.body._id));
   await Promise.all(tagPromises);
+
+  next();
+});
+
+exports.updateTagsFromEdittedPost = catchAsync(async (req, res, next) => {
+  if (!req.body.tags) next();
+
+  // Prepare tag arrays to compare
+  const prevBlogpost = await Blogpost.findById(req.params.id);
+  const prevTags = prevBlogpost.tags || [];
+
+  req.body.tags = parseToTagArr(req.body.tags);
+  const currentTags = [...req.body.tags];
+
+  // Separate which tags to delete and add
+  const tagsToDelete = [];
+  const tagsToAdd = [];
+
+  prevTags.forEach((prevTag) => {
+    if (!currentTags.includes(prevTag)) {
+      tagsToDelete.push(prevTag);
+    }
+  });
+  currentTags.forEach((tag) => {
+    if (!prevTags.includes(tag)) {
+      tagsToAdd.push(tag);
+    }
+  });
+
+  // Update Tag documents in DB
+  const deletionPromises = tagsToDelete.map((tag) =>
+    deleteTagFromDB(tag, req.params.id),
+  );
+  const additionPromises = tagsToAdd.map((tag) =>
+    inputTagIntoDB(tag, req.params.id),
+  );
+  const allTagPromises = deletionPromises.concat(additionPromises);
+  await Promise.all(allTagPromises);
+
   next();
 });
 

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -1,0 +1,16 @@
+const Tag = require("../models/tagModel");
+const factory = require("./handlerFactory");
+
+exports.createTag = factory.createOne(Tag);
+
+exports.setBlogpostIdSearch = (req, res, next) => {
+  if (req.params.blogpostId) {
+    req.query.blogposts = req.params.blogpostId;
+  }
+  req.query.sort = "tag";
+  next();
+};
+exports.getAllTags = factory.getAll(Tag);
+exports.getTag = factory.getOne(Tag);
+exports.updateTag = factory.updateOne(Tag);
+exports.deleteTag = factory.deleteOne(Tag);

--- a/models/blogpostModel.js
+++ b/models/blogpostModel.js
@@ -111,18 +111,18 @@ async function tagCycleImg(doc, itemFlag) {
     .split("/");
   const cloudFilename = pathArray.slice(1).join("/");
 
-  cloudinary.uploader.add_tag(destroyTag, [cloudFilename]);
+  cloudinary.uploader.add_tag([destroyTag, doc.id], [cloudFilename]);
 }
 
 blogpostSchema.post("save", async function () {
-  if (!this.bannerImgUpdate) return;
-  tagCycleImg(this, "banner");
-});
+  if (!this.bannerImgUpdate && !this.blogpostImgUpdate) return;
+  let itemFlags = [];
 
-blogpostSchema.post("save", async function () {
-  if (!this.blogpostImgUpdate) return;
-  tagCycleImg(this, "blogpost");
-  tagCycleImg(this, "blogthumb");
+  if (this.blogpostImgUpdate) itemFlags = ["blogpost", "blogthumb"];
+  if (this.blogpostImgUpdate) itemFlags.push("banner");
+
+  itemFlags.map((flag) => tagCycleImg(this, flag));
+  Promise.all(itemFlags);
 });
 
 const Blogpost = mongoose.model("Blogpost", blogpostSchema);

--- a/models/blogpostModel.js
+++ b/models/blogpostModel.js
@@ -88,6 +88,13 @@ blogpostSchema.pre("save", function (next) {
   next();
 });
 
+blogpostSchema.pre(/^find/, function (next) {
+  if (!this._mongooseOptions.populate) {
+    this.populate({ path: "user", select: "name" });
+  }
+  next();
+});
+
 async function tagCycleImg(doc, itemFlag) {
   if (doc[`${itemFlag}Img`] === `/my-mini-blog/${itemFlag}_img/default/jpg`) {
     return;

--- a/models/blogpostModel.js
+++ b/models/blogpostModel.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 const cloudinary = require("cloudinary").v2;
-const slugify = require("slugify");
+// const slugify = require("slugify");
 
 const blogpostSchema = new mongoose.Schema(
   {
@@ -83,10 +83,10 @@ blogpostSchema.virtual("comments", {
   localField: "_id",
 });
 
-blogpostSchema.pre("save", function (next) {
-  this.slug = slugify(this.title, { lower: true, strict: true });
-  next();
-});
+// blogpostSchema.pre("save", function (next) {
+//   this.slug = slugify(this.title, { lower: true, strict: true });
+//   next();
+// });
 
 blogpostSchema.pre(/^find/, function (next) {
   if (!this._mongooseOptions.populate) {

--- a/models/tagModel.js
+++ b/models/tagModel.js
@@ -1,13 +1,18 @@
 const mongoose = require("mongoose");
 
-const tagSchema = new mongoose.Schema({
-  tag: {
-    type: String,
-    required: [true, "Tag cannot be empty!"],
-    unique: true,
+const tagSchema = new mongoose.Schema(
+  {
+    tag: {
+      type: String,
+      required: [true, "Tag cannot be empty!"],
+      unique: true,
+    },
+    blogposts: [{ type: mongoose.Schema.ObjectId, ref: "Blogpost" }],
   },
-  blogposts: [{ type: mongoose.Schema.ObjectId, ref: "Blogpost" }],
-});
+  {
+    versionKey: false,
+  },
+);
 
 const Tag = mongoose.model("Tag", tagSchema);
 

--- a/models/tagModel.js
+++ b/models/tagModel.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose");
+
+const tagSchema = new mongoose.Schema({
+  tag: {
+    type: String,
+    required: [true, "Tag cannot be empty!"],
+    unique: true,
+  },
+  blogposts: [{ type: mongoose.Schema.ObjectId, ref: "Blogpost" }],
+});
+
+const Tag = mongoose.model("Tag", tagSchema);
+
+module.exports = Tag;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "express.js app for my-mini-blog hosted in netlify",
   "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "dev": "nodemon server.js",
     "build": "npm i"
   },
@@ -23,7 +24,6 @@
     "hpp": "^0.2.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.0.0",
-    "nodemon": "^3.0.1",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.7",

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -12,7 +12,10 @@ router.use("/:blogpostId/tags", tagRouter);
 
 router
   .route("/")
-  .get(blogpostController.getAllBlogposts)
+  .get(
+    blogpostController.setTagsQueryToSliceSearch,
+    blogpostController.getAllBlogposts,
+  )
   .post(
     authController.protect,
     blogpostController.uploadBlogpostImages,

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -2,10 +2,12 @@ const express = require("express");
 const blogpostController = require("../controllers/blogpostController");
 const authController = require("../controllers/authController");
 const commentRouter = require("./commentRoutes");
+const tagRouter = require("./tagRoutes");
 
 const router = express.Router({ mergeParams: true });
 
 router.use("/:blogpostId/comments", commentRouter);
+router.use("/:blogpostId/tags", tagRouter);
 
 router
   .route("/")
@@ -15,14 +17,6 @@ router
     blogpostController.setCreateBlogpostUserId,
     blogpostController.createBlogpost,
   );
-
-router.get("/alltags", blogpostController.getAllTags);
-router.get("/tags", blogpostController.getAllBlogposts);
-router.get(
-  "/tags/:tag",
-  blogpostController.setSearchBlogpostsTags,
-  blogpostController.getAllBlogposts,
-);
 
 router
   .route("/:id")

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const blogpostController = require("../controllers/blogpostController");
 const authController = require("../controllers/authController");
+const tagController = require("../controllers/tagController");
 const commentRouter = require("./commentRoutes");
 const tagRouter = require("./tagRoutes");
 
@@ -16,6 +17,7 @@ router
     authController.protect,
     blogpostController.uploadBlogpostImages,
     blogpostController.setCreateBlogpostUserId,
+    tagController.updateTagFromNewPost,
     blogpostController.setImgUpdatesFalse,
     blogpostController.uploadBannerImgToCloud,
     blogpostController.uploadBlogpostImgToCloud,

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -14,7 +14,11 @@ router
   .get(blogpostController.getAllBlogposts)
   .post(
     authController.protect,
+    blogpostController.uploadBlogpostImages,
     blogpostController.setCreateBlogpostUserId,
+    blogpostController.setImgUpdatesFalse,
+    blogpostController.uploadBannerImgToCloud,
+    blogpostController.uploadBlogpostImgToCloud,
     blogpostController.createBlogpost,
   );
 

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -19,7 +19,8 @@ router
   .post(
     authController.protect,
     blogpostController.uploadBlogpostImages,
-    blogpostController.setCreateBlogpostUserId,
+    blogpostController.checkTitleSlug,
+    blogpostController.setIdsForNewPost,
     blogpostController.setImgUpdatesFalse,
     blogpostController.uploadBannerImgToCloud,
     blogpostController.uploadBlogpostImgToCloud,
@@ -33,6 +34,7 @@ router
   .patch(
     authController.protect,
     blogpostController.uploadBlogpostImages,
+    blogpostController.checkTitleSlug,
     blogpostController.setImgUpdatesFalse,
     blogpostController.uploadBannerImgToCloud,
     blogpostController.uploadBlogpostImgToCloud,

--- a/routes/blogpostRoutes.js
+++ b/routes/blogpostRoutes.js
@@ -17,10 +17,10 @@ router
     authController.protect,
     blogpostController.uploadBlogpostImages,
     blogpostController.setCreateBlogpostUserId,
-    tagController.updateTagFromNewPost,
     blogpostController.setImgUpdatesFalse,
     blogpostController.uploadBannerImgToCloud,
     blogpostController.uploadBlogpostImgToCloud,
+    tagController.updateTagsFromNewPost,
     blogpostController.createBlogpost,
   );
 
@@ -33,11 +33,13 @@ router
     blogpostController.setImgUpdatesFalse,
     blogpostController.uploadBannerImgToCloud,
     blogpostController.uploadBlogpostImgToCloud,
+    tagController.updateTagsFromEdittedPost,
     blogpostController.updateBlogpost,
   )
   .delete(
     authController.protect,
     blogpostController.deleteBlogpostComments,
+    blogpostController.deleteBlogpostTags,
     blogpostController.deleteBlogpost,
   );
 

--- a/routes/tagRoutes.js
+++ b/routes/tagRoutes.js
@@ -1,0 +1,38 @@
+const express = require("express");
+const authController = require("../controllers/authController");
+const tagController = require("../controllers/tagController");
+
+const router = express.Router({ mergeParams: true });
+
+/* TODOS 
+ - getRandomRelatedPosts, /related-posts/:postNum, maybe I can just put it in client side
+ - populate blogposts if search for related posts (summary=true)
+ - middleware to aggregate tags and put it into getBlogpost x I did not think things through
+ - middleware updateTagFromNewPost, updateTagFromEdittedPost
+
+ - add image to new post
+*/
+
+router
+  .route("/")
+  .get(tagController.setBlogpostIdSearch, tagController.getAllTags)
+  .post(
+    authController.protect,
+    authController.restrictTo("admin"),
+    tagController.createTag,
+  );
+
+router
+  .route("/:id")
+  .get(tagController.getTag)
+  .patch(
+    authController.protect,
+    authController.restrictTo("admin"),
+    tagController.updateTag,
+  )
+  .delete(
+    authController.protect,
+    authController.restrictTo("admin"),
+    tagController.deleteTag,
+  );
+module.exports = router;

--- a/routes/tagRoutes.js
+++ b/routes/tagRoutes.js
@@ -6,17 +6,22 @@ const router = express.Router({ mergeParams: true });
 
 /* TODOS 
  - getRandomRelatedPosts, /related-posts/:postNum, maybe I can just put it in client side
- - populate blogposts if search for related posts (summary=true)
+ 
  - middleware to aggregate tags and put it into getBlogpost x I did not think things through
  - delete cloudinary pictures when delete blogpost
 
  - add image to new post
  - middleware updateTagFromNewPost, updateTagFromEdittedPost
+ - populate blogposts if search for related posts (summary=true)
 */
 
 router
   .route("/")
-  .get(tagController.setBlogpostIdSearch, tagController.getAllTags)
+  .get(
+    tagController.setBlogpostIdSearch,
+    tagController.setSearchOperatorsToQuery,
+    tagController.getAllTags,
+  )
   .post(
     authController.protect,
     authController.restrictTo("admin"),

--- a/routes/tagRoutes.js
+++ b/routes/tagRoutes.js
@@ -8,9 +8,10 @@ const router = express.Router({ mergeParams: true });
  - getRandomRelatedPosts, /related-posts/:postNum, maybe I can just put it in client side
  - populate blogposts if search for related posts (summary=true)
  - middleware to aggregate tags and put it into getBlogpost x I did not think things through
- - middleware updateTagFromNewPost, updateTagFromEdittedPost
+ - delete cloudinary pictures when delete blogpost
 
  - add image to new post
+ - middleware updateTagFromNewPost, updateTagFromEdittedPost
 */
 
 router

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "server.js",
+      "use": "@now/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "server.js"
+    }
+  ]
+}


### PR DESCRIPTION
# Backgrounds:
This PR aims to create Tag documents be separated from Blogpost documents for better access. This PR also includes bug fixes for image upload and preparation to switch deployment from render.com to vercel.com. The changes are as following:

1. Adding tagModel and its Mongoose schema.
2. Adding tagRouter in app.js.
3. Adding tagController for both common CRUD routes and specific middlewares to update tags from blogpost's edit.
4. Adding middleware to delete tags when blogpost is deleted.
5. Adding search function to provide more specific blogposts for every tags query and search function to provide more result for tags every tag query.
6. Inserting Cloudinary's API call to delete saved images when related blogpost is deleted.
7. Image upload is now possible from creating blogpost the first time.
8. Adding checkTitleSlug middleware to bypass updating image and tag if slug were already existed when editing or creating new blogpost. (will pass error response)
9. Changing v1 to v2 both in routes and README.md.
10. Adding vercel.json, and start script in package.json, 